### PR TITLE
Move docker VMs to their own subnet, fix up Powershell scripts

### DIFF
--- a/ha-nva-deployment/parameters/ha-nva-docker.parameters.json
+++ b/ha-nva-deployment/parameters/ha-nva-docker.parameters.json
@@ -15,7 +15,7 @@
         "nics": [
           {
             "isPublic": "false",
-            "subnetName": "dmz-internal",
+            "subnetName": "docker",
             "privateIPAllocationMethod": "dynamic",
             "isPrimary": "true",
             "enableIPForwarding": false,

--- a/ha-nva-deployment/sample-test-environment/Deploy.ps1
+++ b/ha-nva-deployment/sample-test-environment/Deploy.ps1
@@ -85,6 +85,16 @@ foreach($subnet in $vnet.Subnets)
         $subnet.RouteTable = $udr2
     }
 }
+
+$route3 = New-AzureRmRouteConfig -Name docker -AddressPrefix 10.0.2.0/24 -NextHopType VirtualAppliance -NextHopIpAddress $nic2.IpConfigurations[0].PrivateIpAddress
+$udr3 = New-AzureRmRouteTable -Name ha-nva-docker-udr -ResourceGroupName $networkResourceGroup.ResourceGroupName -Location $Location -Route $route3
+foreach($subnet in $vnet.Subnets)
+{
+    if($subnet.Name -eq "docker") { 
+        $subnet.RouteTable = $udr3
+    }
+}
+
 Set-AzureRmVirtualNetwork -VirtualNetwork $vnet
 
 Write-Host "Deploying routing extension on NVA vms..."

--- a/ha-nva-deployment/sample-test-environment/Deploy.ps1
+++ b/ha-nva-deployment/sample-test-environment/Deploy.ps1
@@ -70,11 +70,21 @@ $nic2 = Get-AzureRmNetworkInterface -Name ha-nva-vm1-nic2 -ResourceGroupName $ne
 $vnet = Get-AzureRmVirtualNetwork -Name ha-nva-vnet -ResourceGroupName $networkResourceGroup.ResourceGroupName
 $route = New-AzureRmRouteConfig -Name default -AddressPrefix 0.0.0.0/0 -NextHopType VirtualAppliance -NextHopIpAddress $nic2.IpConfigurations[0].PrivateIpAddress
 $udr = New-AzureRmRouteTable -Name ha-nva-udr -ResourceGroupName $networkResourceGroup.ResourceGroupName -Location $Location -Route $route
-$vnet.Subnets[3].RouteTable = $udr
+foreach($subnet in $vnet.Subnets)
+{
+    if($subnet.Name -eq "dmz-internal") { 
+        $subnet.RouteTable = $udr
+    }
+}
 
 $route2 = New-AzureRmRouteConfig -Name web -AddressPrefix 10.0.1.0/24 -NextHopType VirtualAppliance -NextHopIpAddress $nic2.IpConfigurations[0].PrivateIpAddress
 $udr2 = New-AzureRmRouteTable -Name ha-nva-mgmt-udr -ResourceGroupName $networkResourceGroup.ResourceGroupName -Location $Location -Route $route2
-$vnet.Subnets[4].RouteTable = $udr2
+foreach($subnet in $vnet.Subnets)
+{
+    if($subnet.Name -eq "web") { 
+        $subnet.RouteTable = $udr2
+    }
+}
 Set-AzureRmVirtualNetwork -VirtualNetwork $vnet
 
 Write-Host "Deploying routing extension on NVA vms..."

--- a/ha-nva-deployment/sample-test-environment/MoveToNode1.ps1
+++ b/ha-nva-deployment/sample-test-environment/MoveToNode1.ps1
@@ -1,14 +1,26 @@
-﻿$pip = Get-AzureRmPublicIpAddress -Name ha-nva-pip -ResourceGroupName ha-nva-rg
+﻿param(
+  [Parameter(Mandatory=$true)]
+  $SubscriptionId,
+  [Parameter(Mandatory=$false)]
+  $Location = "West US 2",
+  [Parameter(Mandatory=$false)]
+  $ResourceGroupName = "ha-nva-rg"
+)
 
-$nic1 = Get-AzureRmNetworkInterface -ResourceGroupName ha-nva-rg -Name ha-nva-vm2-nic1
+# Login to Azure and select your subscription
+Login-AzureRmAccount -SubscriptionId $SubscriptionId | Out-Null
+
+$pip = Get-AzureRmPublicIpAddress -Name ha-nva-pip -ResourceGroupName $ResourceGroupName
+
+$nic1 = Get-AzureRmNetworkInterface -ResourceGroupName $ResourceGroupName -Name ha-nva-vm2-nic1
 $nic1.IpConfigurations[0].PublicIpAddress = $null
 $nic1 | Set-AzureRmNetworkInterface
 
-$nic2 = Get-AzureRmNetworkInterface -ResourceGroupName ha-nva-rg -Name ha-nva-vm1-nic1
+$nic2 = Get-AzureRmNetworkInterface -ResourceGroupName $ResourceGroupName -Name ha-nva-vm1-nic1
 $nic2.IpConfigurations[0].PublicIpAddress = $pip
 $nic2 | Set-AzureRmNetworkInterface
 
-$rt = Get-AzureRmRouteTable -ResourceGroupName ha-nva-rg -Name ha-nva-udr
+$rt = Get-AzureRmRouteTable -ResourceGroupName $ResourceGroupName -Name ha-nva-udr
 $route = Get-AzureRmRouteConfig -RouteTable $rt -Name default
 $route.NextHopIpAddress="10.0.0.68"
 Set-AzureRmRouteConfig -Name $route.Name -RouteTable $rt -AddressPrefix $route.AddressPrefix -NextHopType $route.NextHopType -NextHopIpAddress $route.NextHopIpAddress

--- a/ha-nva-deployment/sample-test-environment/MoveToNode2.ps1
+++ b/ha-nva-deployment/sample-test-environment/MoveToNode2.ps1
@@ -1,14 +1,26 @@
-﻿$pip = Get-AzureRmPublicIpAddress -Name ha-nva-pip -ResourceGroupName ha-nva-rg
+﻿param(
+  [Parameter(Mandatory=$true)]
+  $SubscriptionId,
+  [Parameter(Mandatory=$false)]
+  $Location = "West US 2",
+  [Parameter(Mandatory=$false)]
+  $ResourceGroupName = "ha-nva-rg"
+)
 
-$nic1 = Get-AzureRmNetworkInterface -ResourceGroupName ha-nva-rg -Name ha-nva-vm1-nic1
+# Login to Azure and select your subscription
+Login-AzureRmAccount -SubscriptionId $SubscriptionId | Out-Null
+
+$pip = Get-AzureRmPublicIpAddress -Name ha-nva-pip -ResourceGroupName $ResourceGroupName
+
+$nic1 = Get-AzureRmNetworkInterface -ResourceGroupName $ResourceGroupName -Name ha-nva-vm1-nic1
 $nic1.IpConfigurations[0].PublicIpAddress = $null
 $nic1 | Set-AzureRmNetworkInterface
 
-$nic2 = Get-AzureRmNetworkInterface -ResourceGroupName ha-nva-rg -Name ha-nva-vm2-nic1
+$nic2 = Get-AzureRmNetworkInterface -ResourceGroupName $ResourceGroupName -Name ha-nva-vm2-nic1
 $nic2.IpConfigurations[0].PublicIpAddress = $pip
 $nic2 | Set-AzureRmNetworkInterface
 
-$rt = Get-AzureRmRouteTable -ResourceGroupName ha-nva-rg -Name ha-nva-udr
+$rt = Get-AzureRmRouteTable -ResourceGroupName $ResourceGroupName -Name ha-nva-udr
 $route = Get-AzureRmRouteConfig -RouteTable $rt -Name default
 $route.NextHopIpAddress="10.0.0.69"
 Set-AzureRmRouteConfig -Name $route.Name -RouteTable $rt -AddressPrefix $route.AddressPrefix -NextHopType $route.NextHopType -NextHopIpAddress $route.NextHopIpAddress

--- a/ha-nva-deployment/sample-test-environment/ha-nva-vnet.parameters.json
+++ b/ha-nva-deployment/sample-test-environment/ha-nva-vnet.parameters.json
@@ -25,6 +25,10 @@
           {
             "name": "web",
             "addressPrefix": "10.0.1.0/24"
+          },
+          {
+            "name": "docker",
+            "addressPrefix": "10.0.2.0/24"
           }
         ],
         "dnsServers": [ ]


### PR DESCRIPTION
The docker VMs were deployed the 'dmz-internal' subnet which meant there was no network route and extensions couldn't be deployed. I created a new subnet named 'docker' and put the docker VMs there. There was also a bug in the Powershell scripts - in the deploy.ps1 script, referring to the nic by array index didn't work consistently, so I changed it to reference them by name. I also had to create a new route for the docker VMs since they are in a different subnet now. The movetonode1 and 2 powershell scripts didn't have code to log in, so I added that as well.