### PR TITLE
Update Dependencies, Fix Build

### DIFF
--- a/nvadaemon-azure/pom.xml
+++ b/nvadaemon-azure/pom.xml
@@ -14,17 +14,17 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.5.0</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>adapter-rxjava</artifactId>
-            <version>2.1.0</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>2.5.0</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okio</groupId>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0.pr1</version>
+            <version>2.10.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/nvadaemon/pom.xml
+++ b/nvadaemon/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0.pr1</version>
+            <version>2.10.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Update jackson-databind to non-pr version and guava to latest.

Commit 0a6ee92 broke some tests.  Updating retrofit to 2.5.0 brings okhttp up to version 3.12, which breaks compatibility with previous version.  It appears that 2.4.0 is the latest version of retrofit we can use without addressing these changes.

Testing done: full build of ha-nva, nvadaemon, nvadaemon-azure, nvadaemon-assembly and all unit tests passing.