### PR TITLE
Update retrofit and okhttp

### DIFF
--- a/nvadaemon-azure/pom.xml
+++ b/nvadaemon-azure/pom.xml
@@ -14,17 +14,17 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.4.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>adapter-rxjava</artifactId>
-            <version>2.4.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>2.4.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okio</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.4.1</version>
+            <version>3.14.9</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex</groupId>


### PR DESCRIPTION
Update retrofit to latest version because of security issues in 2.4

Update okhttp to be compatible with latest retrofit version

Testing done: build and unit tests.

Supersedes: #64